### PR TITLE
Add Events and APIs

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -53,6 +53,14 @@ return function (Filter $filter, Dispatcher $events) {
                 Route::post('', 'WhitelistController@add');
                 Route::delete('', 'WhitelistController@delete');
             });
+
+        Route::namespace('LittleSkin\TextureModeration\Controllers')
+            ->middleware(['api', 'auth:oauth', 'role:admin'])
+            ->prefix('api/admin/texture-moderation')
+            ->group(function () {
+                Route::get('', 'TextureModerationController@manage')->middleware(['scope:TextureModeration.Read,TextureModeration.ReadWrite']);
+                Route::put('{record}', 'TextureModerationController@review')->middleware(['scope:TextureModeration.ReadWrite']);
+            });
     });
 
     Hook::addMenuItem('admin', 4001, [

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Texture;
 use App\Services\Hook;
 use Blessing\Filter;
 use Blessing\Rejection;
@@ -12,7 +13,9 @@ use LittleSkin\TextureModeration\ReviewState;
 use LittleSkin\TextureModeration\RecordSource;
 
 return function (Filter $filter, Dispatcher $events) {
-    $events->listen('texture.uploaded', OnTextureUploaded::class);
+    $events->listen('texture.uploaded', function (Texture $texture) use ($events) {
+        return OnTextureUploaded::handle($texture, $events);
+    });
     $events->listen('texture.deleted', OnTextureDeleted::class);
 
     $filter->add('can_update_texture_privacy', function ($can, $texture) {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -41,7 +41,7 @@ return function (Filter $filter, Dispatcher $events) {
             ->prefix('admin/texture-moderation')
             ->group(function () {
                 Route::get('', 'TextureModerationController@show');
-                Route::post('review', 'TextureModerationController@review');
+                Route::put('review/{record}', 'TextureModerationController@review');
                 Route::get('list', 'TextureModerationController@manage');
             });
 

--- a/callbacks.php
+++ b/callbacks.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Scope;
+
 return [
     App\Events\PluginWasEnabled::class => function () {
         if (!Schema::hasTable('moderation_whitelist')) {
@@ -24,6 +26,20 @@ return [
                 $table->integer('operator')->nullable();
                 $table->timestamps();
             });
+        }
+
+        if(!Scope::where('name', 'TextureModeration.Read')->exists()) {
+            Scope::create([
+                'name' => 'TextureModeration.Read',
+                'description' => 'Ability to read texture moderation records'
+            ]);
+        }
+
+        if(!Scope::where('name', 'TextureModeration.ReadWrite')->exists()) {
+            Scope::create([
+                'name' => 'TextureModeration.ReadWrite',
+                'description' => 'Ability to read and write texture moderation records'
+            ]);
         }
     },
 ];

--- a/callbacks.php
+++ b/callbacks.php
@@ -28,14 +28,14 @@ return [
             });
         }
 
-        if(!Scope::where('name', 'TextureModeration.Read')->exists()) {
+        if (!Scope::where('name', 'TextureModeration.Read')->exists()) {
             Scope::create([
                 'name' => 'TextureModeration.Read',
                 'description' => 'Ability to read texture moderation records'
             ]);
         }
 
-        if(!Scope::where('name', 'TextureModeration.ReadWrite')->exists()) {
+        if (!Scope::where('name', 'TextureModeration.ReadWrite')->exists()) {
             Scope::create([
                 'name' => 'TextureModeration.ReadWrite',
                 'description' => 'Ability to read and write texture moderation records'

--- a/src/Controllers/TextureModerationController.php
+++ b/src/Controllers/TextureModerationController.php
@@ -77,10 +77,10 @@ class TextureModerationController extends Controller
                 $record->review_state = ReviewState::REJECTED;
 
                 $record->save();
-                
+
                 $texture = Texture::where('tid', $tid)->first();
-                
-                if($record->source === RecordSource::ON_PRIVACY_UPDATED){
+
+                if ($record->source === RecordSource::ON_PRIVACY_UPDATED) {
                     $texture->public = false;
                     $texture->save();
 
@@ -105,7 +105,7 @@ class TextureModerationController extends Controller
 
                 return json(trans('LittleSkin\TextureModeration::manage.message.deleted'), 0);
 
-                break; 
+                break;
             case 'private':
                 $record->review_state = ReviewState::REJECTED;
 

--- a/src/Controllers/TextureModerationController.php
+++ b/src/Controllers/TextureModerationController.php
@@ -35,10 +35,7 @@ class TextureModerationController extends Controller
         $q = $request->input('q');
 
         return ModerationRecord::usingSearchString($q)
-            ->leftJoin('users as operator', 'operator.uid', '=', 'moderation_records.operator')
-            ->leftJoin('textures', 'textures.tid', '=', 'moderation_records.tid')
-            ->leftJoin('users', 'users.uid', '=', 'textures.uploader')
-            ->select(['textures.uploader', 'users.uid', 'users.nickname', 'moderation_records.*', 'operator.nickname as operator_nickname'])
+            ->with(['texture:tid,name,type,uploader', 'texture.owner:uid,nickname', 'operator:uid,nickname'])
             ->paginate(9);
     }
 

--- a/src/Listeners/OnTextureUploaded.php
+++ b/src/Listeners/OnTextureUploaded.php
@@ -3,15 +3,16 @@
 namespace LittleSkin\TextureModeration\Listeners;
 
 use App\Models\Texture;
+use Illuminate\Contracts\Events\Dispatcher;
 use LittleSkin\TextureModeration\Controllers\ModerationController;
 use LittleSkin\TextureModeration\RecordSource;
 
 class OnTextureUploaded
 {
-    public function handle(Texture $texture)
+    public static function handle(Texture $texture, Dispatcher $dispatcher)
     {
         if ($texture->public) {
-            return ModerationController::start($texture, RecordSource::ON_PUBLIC_UPLOAD);
+            return ModerationController::start($texture, RecordSource::ON_PUBLIC_UPLOAD, $dispatcher);
         }
     }
 }

--- a/src/Models/ModerationRecord.php
+++ b/src/Models/ModerationRecord.php
@@ -34,6 +34,10 @@ class ModerationRecord extends Model
 
     public function texture()
     {
-        return $this->belongsTo('App\Models\Texture');
+        return $this->belongsTo('App\Models\Texture', 'tid', 'tid');
+    }
+
+    public function operator() {
+        return $this->belongsTo('App\Models\User', 'operator', 'uid');
     }
 }

--- a/src/Models/ModerationRecord.php
+++ b/src/Models/ModerationRecord.php
@@ -37,7 +37,8 @@ class ModerationRecord extends Model
         return $this->belongsTo('App\Models\Texture', 'tid', 'tid');
     }
 
-    public function operator() {
+    public function operator()
+    {
         return $this->belongsTo('App\Models\User', 'operator', 'uid');
     }
 }

--- a/views/moderation.jsx
+++ b/views/moderation.jsx
@@ -106,11 +106,11 @@ const App = () => {
           {list.map(v => (
             <div className="card mr-3 mb-3" style={{ width: 240 }} onClick={() => setViewing(v)}>
               <div className="card-header">
-                {v.uploader ? (
+                {v.texture ? (
                   <><b>{t('texture-moderation.uploader')}：</b>
-                    <span className="mr-1">{v.nickname}</span>
+                    <span className="mr-1">{v.texture.owner.nickname}</span>
                     (UID:
-                    {v.uploader})
+                    {v.texture.owner.uid})
                   </>
                 ) :
                   <b>{t('texture-moderation.deleted')}</b>}
@@ -133,8 +133,8 @@ const App = () => {
                 <div>
                   <b>{t('texture-moderation.operator')}: </b>
                   {v.operator ? (
-                    <>{v.operator_nickname} (UID:
-                      {v.operator})</>
+                    <>{v.operator.nickname} (UID:
+                      {v.operator.uid})</>
                   ) : <>{t('texture-moderation.machine-review')}</>}
                 </div>
                 <div>

--- a/views/moderation.jsx
+++ b/views/moderation.jsx
@@ -74,8 +74,7 @@ const App = () => {
     setMaxPage(last_page)
   }
   const submit = async (action) => {
-    let r = await bsFetch.post('/admin/texture-moderation/review', {
-      id: viewing.tid,
+    let r = await bsFetch.put('/admin/texture-moderation/review/' + viewing.id, {
       action
     })
     if (r.code === 0) {


### PR DESCRIPTION
照着 Laravel 文档和 BS 源码，依葫芦画瓢写出来的

主要就是做了以下两件事：
- 把 `POST /admin/texture-moderation/review` 的路由改成了 `PUT /admin/texture-moderation/review/{record}`，其中 record 参数是材质审核记录的 ID，然后添加了一些事件以及 API 用的路由和 Scope
- 把 TextureModerationController 里的 `manage()` 方法用 Eloquent ORM 重写了一下，对应的前端变量什么的也修改了